### PR TITLE
undent 'spec:'

### DIFF
--- a/5-1-kuard-pod.yaml
+++ b/5-1-kuard-pod.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: kuard
-  spec:
-    containers:
-    - image: gcr.io/kuar-demo/kuard-amd64:1
-      name: kuard
-      ports:
-      - containerPort: 8080
-        name: http
-        protocol: TCP
+spec:
+  containers:
+  - image: gcr.io/kuar-demo/kuard-amd64:1
+    name: kuard
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP


### PR DESCRIPTION
`kubectl create -f https://raw.githubusercontent.com/kubernetes-up-and-running/examples/master/5-1-kuard-pod.yaml` 
fails with
`error: error validating "https://raw.githubusercontent.com/kubernetes-up-and-running/examples/master/5-1-kuard-pod.yaml": error validating data: found invalid field spec for v1.ObjectMeta; if you choose to ignore these errors, turn validation off with --validate=false`