### PR TITLE
Updated parse-server env-vars to correct ones

### DIFF
--- a/14-1-parse.yaml
+++ b/14-1-parse.yaml
@@ -14,11 +14,11 @@ spec:
       - name: parse-server
         image: ${DOCKER_USER}/parse-server
         env:
-        - name: DATABASE_URI
+        - name: PARSE_SERVER_DATABASE_URI
           value: "mongodb://mongo-0.mongo:27017,\
             mongo-1.mongo:27017,mongo-2.mongo\
             :27017/dev?replicaSet=rs0"
-        - name: APP_ID
+        - name: PARSE_SERVER_APP_ID
           value: my-app-id
-        - name: MASTER_KEY
+        - name: PARSE_SERVER_MASTER_KEY
           value: my-master-key


### PR DESCRIPTION
When I tried to run parse.yaml in kubernetes (like the book explained), the container failed to start because of missing environment variables. 

According to https://github.com/parse-community/parse-server#using-environment-variables-to-configure-parse-server , the environment variables are prefixed with `PARSE_SERVER_`

