### PR TITLE
Edited YAML for 5-1 kuard pod

### DIFF
--- a/5-1-kuard-pod.yaml
+++ b/5-1-kuard-pod.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: kuard
-  spec:
-    containers:
-    - image: gcr.io/kuar-demo/kuard-amd64:1
-      name: kuard
-      ports:
-      - containerPort: 8080
-        name: http
-        protocol: TCP
+spec:
+  containers:
+  - image: gcr.io/kuar-demo/kuard-amd64:1
+    name: kuard
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP


### PR DESCRIPTION
The indentation for ' spec' wasn't correct and this wouldn't deploy. The indentation in the book itself is correct. I changed it to a working deployment.

FYI: this was the error I got with the initial deployment: 
error: error validating "test-with-space.yaml": error validating data: ValidationError(Pod.metadata): unknown field "spec" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta; if you choose to ignore these errors, turn validation off with --validate=false