### PR TITLE
Fix 14-4-ghost.yaml

### DIFF
--- a/14-4-ghost.yaml
+++ b/14-4-ghost.yaml
@@ -19,7 +19,7 @@ spec:
         - sh
         - -c
         - cp /ghost-config/ghost-config.js /var/lib/ghost/config.js
-          && /entrypoint.sh npm start
+          && docker-entrypoint.sh node current/index.js
         volumeMounts:
         - mountPath: /ghost-config
           name: config

--- a/14-4-ghost.yaml
+++ b/14-4-ghost.yaml
@@ -18,7 +18,7 @@ spec:
         command:
         - sh
         - -c
-        - cp /ghost-config/config.js /var/lib/ghost/config.js
+        - cp /ghost-config/ghost-config.js /var/lib/ghost/config.js
           && /entrypoint.sh npm start
         volumeMounts:
         - mountPath: /ghost-config


### PR DESCRIPTION
I tried to deploy Ghost by applying `14-4-ghost.yaml`.
But it failed because of some errors.

## Align the path of config file with the book

In the book, the config file is registered as below:

```
$ kubectl create cm --from-file ghost-config.js ghost-config
```

So the file name should be `ghost-config.js`.

## Align the Docker image of Ghost 1.22.1

https://github.com/docker-library/ghost/blob/47f1ab8767c6547455dbddc0508c1856ddefde77/1/debian/Dockerfile#L78-L82