### PR TITLE
Update 14-1-parse.yaml file

### DIFF
--- a/14-1-parse.yaml
+++ b/14-1-parse.yaml
@@ -19,6 +19,6 @@ spec:
             mongo-1.mongo:27017,mongo-2.mongo\
             :27017/dev?replicaSet=rs0"
         - name: PARSE_SERVER_APP_ID
-          value: my-app-id
+          value: "my-app-id"
         - name: PARSE_SERVER_MASTER_KEY
-          value: my-master-key
+          value: "my-master-key"


### PR DESCRIPTION
Crashed due to environmental variables not being in quotes for APP_ID and MASTER_KEY
Tested against: Server Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.3", Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.3"