### PR TITLE
Update 8-1-kuard-rs.yaml

### DIFF
--- a/8-1-kuard-rs.yaml
+++ b/8-1-kuard-rs.yaml
@@ -1,9 +1,16 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: kuard
+  labels:
+    app: kuard
+    version: "2"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kuard
+      version: "2"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Manifest seems to have become out dated. When applying it failed with " no matches for kind "ReplicaSet" in version "extensions/v1beta1"". Newer definitions call for a "selector" section. Not sure if it exactly matches the author's intent, but it works, so seems like an improvement.